### PR TITLE
only consider bloat images with the EXIF tag set by Kometa

### DIFF
--- a/imagemaid.py
+++ b/imagemaid.py
@@ -330,7 +330,7 @@ def run_imagemaid(attrs):
                                 else:
                                     messages.append(f"BLOAT FILE: {path}")
                             else:
-                                messages.append(f"IMAGE FILE: {path} does not have EXIF overlay tag and won't be considered.")
+                                messages.append(f"FILE: {path} does not have EXIF overlay tag and won't be considered.")
                     for message in messages:
                         if mode == "report":
                             logger.debug(message)

--- a/imagemaid.py
+++ b/imagemaid.py
@@ -316,21 +316,24 @@ def run_imagemaid(attrs):
                     messages = []
                     bloat_paths_filtered = []
                     for path in tqdm(bloat_paths, unit=f" {modes[mode]['ed'].lower()}", desc=f"| {modes[mode]['ing']} Bloat Images"):
+                        imageIsBloat = False
                         with Image.open(path) as image:
                             exif_tags = image.getexif()
                             if 0x04bc in exif_tags and exif_tags[0x04bc] == "overlay":
-                                logger["size"] += os.path.getsize(path)
-                                bloat_paths_filtered.append(path)
-                                if mode == "move":
-                                    messages.append(f"MOVE: {path} --> {os.path.join(restore_dir, path.removeprefix(meta_dir)[1:])}.jpg")
-                                    util.move_path(path, meta_dir, restore_dir, suffix=".jpg")
-                                elif mode == "remove":
-                                    messages.append(f"REMOVE: {path}")
-                                    os.remove(path)
-                                else:
-                                    messages.append(f"BLOAT FILE: {path}")
+                                imageIsBloat = True
+                        if imageIsBloat:
+                            logger["size"] += os.path.getsize(path)
+                            bloat_paths_filtered.append(path)
+                            if mode == "move":
+                                messages.append(f"MOVE: {path} --> {os.path.join(restore_dir, path.removeprefix(meta_dir)[1:])}.jpg")
+                                util.move_path(path, meta_dir, restore_dir, suffix=".jpg")
+                            elif mode == "remove":
+                                messages.append(f"REMOVE: {path}")
+                                os.remove(path)
                             else:
-                                messages.append(f"FILE: {path} does not have EXIF overlay tag and won't be considered.")
+                                messages.append(f"BLOAT FILE: {path}")
+                        else:
+                            messages.append(f"FILE: {path} does not have EXIF overlay tag and won't be considered.")
                     for message in messages:
                         if mode == "report":
                             logger.debug(message)

--- a/imagemaid.py
+++ b/imagemaid.py
@@ -330,7 +330,7 @@ def run_imagemaid(attrs):
                                 else:
                                     messages.append(f"BLOAT FILE: {path}")
                             else:
-                                messages.append(f"{modes[mode]['ing']} {path} does not have EXIF overlay tag and won't be considered.")
+                                messages.append(f"IMAGE FILE: {path} does not have EXIF overlay tag and won't be considered.")
                     for message in messages:
                         if mode == "report":
                             logger.debug(message)

--- a/imagemaid.py
+++ b/imagemaid.py
@@ -3,6 +3,7 @@ from concurrent.futures import ProcessPoolExecutor
 from contextlib import closing
 from datetime import datetime
 from urllib.parse import quote
+from PIL import Image
 
 if sys.version_info[0] != 3 or sys.version_info[1] < 11:
     print("Version Error: Version: %s.%s.%s incompatible please use Python 3.11+" % (sys.version_info[0], sys.version_info[1], sys.version_info[2]))
@@ -313,27 +314,34 @@ def run_imagemaid(attrs):
                     logger.info(f"{modes[mode]['ing']} Bloat Images", start="work")
                     logger["size"] = 0
                     messages = []
+                    bloat_paths_filtered = []
                     for path in tqdm(bloat_paths, unit=f" {modes[mode]['ed'].lower()}", desc=f"| {modes[mode]['ing']} Bloat Images"):
-                        logger["size"] += os.path.getsize(path)
-                        if mode == "move":
-                            messages.append(f"MOVE: {path} --> {os.path.join(restore_dir, path.removeprefix(meta_dir)[1:])}.jpg")
-                            util.move_path(path, meta_dir, restore_dir, suffix=".jpg")
-                        elif mode == "remove":
-                            messages.append(f"REMOVE: {path}")
-                            os.remove(path)
-                        else:
-                            messages.append(f"BLOAT FILE: {path}")
+                        with Image.open(path) as image:
+                            exif_tags = image.getexif()
+                            if 0x04bc in exif_tags and exif_tags[0x04bc] == "overlay":
+                                logger["size"] += os.path.getsize(path)
+                                bloat_paths_filtered.append(path)
+                                if mode == "move":
+                                    messages.append(f"MOVE: {path} --> {os.path.join(restore_dir, path.removeprefix(meta_dir)[1:])}.jpg")
+                                    util.move_path(path, meta_dir, restore_dir, suffix=".jpg")
+                                elif mode == "remove":
+                                    messages.append(f"REMOVE: {path}")
+                                    os.remove(path)
+                                else:
+                                    messages.append(f"BLOAT FILE: {path}")
+                            else:
+                                messages.append(f"{modes[mode]['ing']} {path} does not have EXIF overlay tag and won't be considered.")
                     for message in messages:
                         if mode == "report":
                             logger.debug(message)
                         else:
                             logger.trace(message)
-                    logger.info(f"{modes[mode]['ing']} Complete: {modes[mode]['ed']} {len(bloat_paths)} Bloat Images")
+                    logger.info(f"{modes[mode]['ing']} Complete: {modes[mode]['ed']} {len(bloat_paths_filtered)} Bloat Images ({len(bloat_paths)})")
                     space = util.format_bytes(logger["size"])
                     logger.info(f"{modes[mode]['space']}: {space}")
                     logger.info(f"Runtime: {logger.runtime()}")
                     report.append([(f"{modes[mode]['ing']} Bloat Images", "")])
-                    report.append([("", f"{space} of {modes[mode]['space']} {modes[mode]['ing']} {len(bloat_paths)} Files")])
+                    report.append([("", f"{space} of {modes[mode]['space']} {modes[mode]['ing']} {len(bloat_paths_filtered)} Files  ({len(bloat_paths)})")])
                     report.append([("Scan Time", f"{logger.runtime('scanning')}"), (f"{mode.capitalize()} Time", f"{logger.runtime('work')}")])
             elif mode in ["restore", "clear"]:
                 if not os.path.exists(restore_dir):


### PR DESCRIPTION
## Description

Edit to only consider bloat images with the EXIF tag set by Kometa `exif_tags[0x04bc] == "overlay"`

This will allow custom upload images to be kept, and only delete the actual "bloat" images created by Kometa when a new poster is generated.

three line snippet from the log file for operation `report`, showing one file that is skipped (custom upload file):
``` txt
[2024-10-09 01:00:59,117] [imagemaid.py:336]          [DEBUG]    | BLOAT FILE: \\fs2\docker\plex\Library\Application Support\Plex Media Server\Metadata\Movies\9\90c7a3c30a60d1150d94205109a5a2b74485cdf.bundle\Uploads\posters\36e4a268b6d4df0bc9f66aa775d3704a1eb44619 |
[2024-10-09 01:00:59,117] [imagemaid.py:336]          [DEBUG]    | IMAGE FILE: \\fs2\docker\plex\Library\Application Support\Plex Media Server\Metadata\Movies\a\ade61580dc88ae8181b9df68aba0b59d40c5a93.bundle\Uploads\posters\d2a12a4a004bcdb4b4269560f8ce868ceae9f6d9 does not have EXIF overlay tag and won't be considered. |
[2024-10-09 01:00:59,117] [imagemaid.py:336]          [DEBUG]    | BLOAT FILE: \\fs2\docker\plex\Library\Application Support\Plex Media Server\Metadata\Movies\a\eb03f784819ccf7eac36ecbe03bded317864837.bundle\Uploads\posters\e12984d3d6cdc86dc085a924b3bdbeb1c862f66c |
```

three line snippet from the log file for operation `remove`, showing one file that is skipped (custom upload file):
``` txt
[2024-10-09 01:32:24,708] [imagemaid.py:338]          [TRACE]    | REMOVE: \\fs2\docker\plex\Library\Application Support\Plex Media Server\Metadata\Movies\9\90c7a3c30a60d1150d94205109a5a2b74485cdf.bundle\Uploads\posters\36e4a268b6d4df0bc9f66aa775d3704a1eb44619 |
[2024-10-09 01:32:24,708] [imagemaid.py:338]          [TRACE]    | IMAGE FILE: \\fs2\docker\plex\Library\Application Support\Plex Media Server\Metadata\Movies\a\ade61580dc88ae8181b9df68aba0b59d40c5a93.bundle\Uploads\posters\d2a12a4a004bcdb4b4269560f8ce868ceae9f6d9 does not have EXIF overlay tag and won't be considered. |
[2024-10-09 01:32:24,708] [imagemaid.py:338]          [TRACE]    | REMOVE: \\fs2\docker\plex\Library\Application Support\Plex Media Server\Metadata\Movies\a\eb03f784819ccf7eac36ecbe03bded317864837.bundle\Uploads\posters\e12984d3d6cdc86dc085a924b3bdbeb1c862f66c |
```

### Issues Fixed or Closed

- Fixes #82 

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code was submitted to the develop branch of the repository.
